### PR TITLE
Add support for escaping quotes

### DIFF
--- a/src/main/java/io/github/jochyoua/offlinecommands/OfflineCommandsUtils.java
+++ b/src/main/java/io/github/jochyoua/offlinecommands/OfflineCommandsUtils.java
@@ -95,4 +95,32 @@ public class OfflineCommandsUtils {
         command = preparePlaceholders(command, player);
         return command;
     }
+
+    public static String getValue(String valueType, String[] args) {
+        StringBuilder value = new StringBuilder();
+
+        boolean foundType = false;
+        for (String arg : args) {
+            int start = 0;
+            if (!foundType) {
+                String typePrefix = valueType + "=\"";
+                if (arg.startsWith(typePrefix)) {
+                    foundType = true;
+                    start = typePrefix.length();
+                }
+            } else {
+                value.append(' ');
+            }
+            if (foundType) {
+                if (arg.endsWith("\"") && !arg.endsWith("\\\"")) {
+                    value.append(arg, start, arg.length() - 1);
+                    return value.toString().replace("\\\"", "\"");
+                } else {
+                    value.append(arg, start, arg.length());
+                }
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/io/github/jochyoua/offlinecommands/commands/OfflineCommandExecutor.java
+++ b/src/main/java/io/github/jochyoua/offlinecommands/commands/OfflineCommandExecutor.java
@@ -19,17 +19,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static io.github.jochyoua.offlinecommands.OfflineCommandsUtils.color;
 import static io.github.jochyoua.offlinecommands.OfflineCommandsUtils.prepareCommand;
 
 public class OfflineCommandExecutor implements CommandExecutor, TabCompleter {
-    private static final Pattern COMMAND_PATTERN = Pattern.compile("command=\"([^\"]*)\"");
-    private static final Pattern EXECUTOR_PATTERN = Pattern.compile("executor=\"([^\"]*)\"");
-    private static final Pattern USER_PATTERN = Pattern.compile("user=\"([^\"]*)\"");
-
     private final static List<String> BASE_ARGS = Arrays.asList("help", "list", "add", "remove");
 
     private final OfflineCommands plugin;
@@ -81,29 +75,14 @@ public class OfflineCommandExecutor implements CommandExecutor, TabCompleter {
             OfflineCommandsUtils.sendMessage(sender, (color(plugin.getConfig().getString("variables.only-console"))), feedback);
             return true;
         }
-        StringBuilder commandStringBuilder = new StringBuilder();
-        for (int i = 1; i < args.length; i++) {
-            commandStringBuilder.append(" ").append(args[i]);
+        if (args.length < 3) {
+            OfflineCommandsUtils.sendMessage(sender, (color(plugin.getConfig().getString("variables.incorrect-syntax"))), feedback);
+            return true;
         }
 
-        String user = null;
-        String executor = null;
-        String commandToAdd = null;
-
-        Matcher executorMatcher = EXECUTOR_PATTERN.matcher(commandStringBuilder);
-        while (executorMatcher.find()) {
-            executor = executorMatcher.group(1);
-        }
-
-        Matcher commandMatcher = COMMAND_PATTERN.matcher(commandStringBuilder);
-        while (commandMatcher.find()) {
-            commandToAdd = commandMatcher.group(1);
-        }
-
-        Matcher userMatcher = USER_PATTERN.matcher(commandStringBuilder);
-        while (userMatcher.find()) {
-            user = userMatcher.group(1);
-        }
+        String user = OfflineCommandsUtils.getValue("user", args);
+        String executor = OfflineCommandsUtils.getValue("executor", args);
+        String commandToAdd = OfflineCommandsUtils.getValue("command", args);
 
         if (executor == null) {
             executor = "CONSOLE";


### PR DESCRIPTION
This adds support for escaping quotes inside the parameter values. This is done by manually scanning the arguments instead of using regex (as I personally wasn't able to get a regex to work like that and I believe that this is faster anyways).

Main use cases for this is scheduling commands that itself include quotes. Before that would terminate the command argument value with no way to fix that, now one can write something like `command="command \"with quotes\""` and it will still work.